### PR TITLE
partners.txt - added Deloitte and mobile friendly 

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -74,29 +74,29 @@ const services = [
 	// },
 ];
 
-const socials = [
-	{
-		name: "Discord",
-		link: "https://discord.gg/school",
-	},
-	{
-		name: "Instagram",
-		link: "https://www.instagram.com/school.simplified/",
-	},
-	{
-		name: "Tiktok",
-		link: "https://www.tiktok.com/@schoolsimplified",
-	},
+// const socials = [
+// 	{
+// 		name: "Discord",
+// 		link: "https://discord.gg/school",
+// 	},
+// 	{
+// 		name: "Instagram",
+// 		link: "https://www.instagram.com/school.simplified/",
+// 	},
+// 	{
+// 		name: "Tiktok",
+// 		link: "https://www.tiktok.com/@schoolsimplified",
+// 	},
 
-	{
-		name: "Linkedin",
-		link: "https://www.linkedin.com/company/school-simplified",
-	},
-	{
-		name: "Twitter",
-		link: "https://twitter.com/schoolsimplify/",
-	},
-];
+// 	{
+// 		name: "Linkedin",
+// 		link: "https://www.linkedin.com/company/school-simplified",
+// 	},
+// 	{
+// 		name: "Twitter",
+// 		link: "https://twitter.com/schoolsimplify/",
+// 	},
+// ];
 
 // eslint-disable-next-line import/no-default-export
 export default function Footer(): JSX.Element {
@@ -164,7 +164,7 @@ export default function Footer(): JSX.Element {
 								})}
 							</UnorderedList>
 						</Box>
-						<Box my={3}>
+						{/* <Box my={3}>
 							<Heading size="md" color="white" mb={2}>
 								Social Media
 							</Heading>
@@ -187,7 +187,7 @@ export default function Footer(): JSX.Element {
 									);
 								})}
 							</UnorderedList>
-						</Box>
+						</Box> */}
 					</Flex>
 				</ContainerInside>
 			</Container>

--- a/src/pages/links.tsx
+++ b/src/pages/links.tsx
@@ -151,7 +151,7 @@ export default function Links(): JSX.Element {
 							</Button>
 						</Link>
 
-						<Link
+						{/* <Link
 							href="https://www.tiktok.com/@schoolsimplified?"
 							isExternal
 							w="100%"
@@ -274,7 +274,7 @@ export default function Links(): JSX.Element {
 							>
 								<Text flex={1}>Linkedin</Text>
 							</Button>
-						</Link>
+						</Link> */}
 					</VStack>
 				</ContainerInside>
 			</Container>

--- a/src/pages/partners.tsx
+++ b/src/pages/partners.tsx
@@ -81,21 +81,21 @@ export default function partners(): ReactElement {
 				<ContainerInside>
 					<Heading mb={10}>Our Partners</Heading>
 					<Tabs variant="line" colorScheme="purple" align="center">
-						<Box py={2} backgroundColor="#D8D6EC">
+						<Box backgroundColor="#D8D6EC">
 							<TabList
 								justify="center"
 								align="center"
 								color="#8287BE"
 							>
 								<Tab
-									_selected={{ textDecoration: "underline" }}
-									fontWeight={100}
-									py={3}
+									_selected={{
+										borderBottom: "5px solid #8287BE",
+									}}
+									pt={3}
 								>
 									<Heading
 										fontSize={{
 											base: 13,
-											sm: 20,
 											md: 20,
 											lg: 30,
 										}}
@@ -105,12 +105,14 @@ export default function partners(): ReactElement {
 									</Heading>
 								</Tab>
 								<Tab
-									_selected={{ textDecoration: "underline" }}
+									_selected={{
+										borderBottom: "5px solid #8287BE",
+									}}
+									pt={3}
 								>
 									<Heading
 										fontSize={{
 											base: 13,
-											sm: 20,
 											md: 20,
 											lg: 30,
 										}}
@@ -120,12 +122,14 @@ export default function partners(): ReactElement {
 									</Heading>
 								</Tab>
 								<Tab
-									_selected={{ textDecoration: "underline" }}
+									_selected={{
+										borderBottom: "5px solid #8287BE",
+									}}
+									pt={3}
 								>
 									<Heading
 										fontSize={{
 											base: 13,
-											sm: 20,
 											md: 20,
 											lg: 30,
 										}}
@@ -140,8 +144,15 @@ export default function partners(): ReactElement {
 						<TabPanels mt={10}>
 							<TabPanel>
 								<SimpleGrid
-									minChildWidth="250px"
-									spacing="40px"
+									columns={[2, null, 3]}
+									spacing="20px"
+									minChildWidth={{
+										base: 170,
+										sm: 140,
+										md: 250,
+										lg: 200,
+									}}
+									spacingY={0}
 								>
 									<Cell
 										alt="Slingshot"
@@ -152,88 +163,36 @@ export default function partners(): ReactElement {
 										src="/partners/versatile.png"
 									/>
 									<Cell
-										alt="Slingshot"
-										src="/partners/slingshot.png"
-									/>
-									<Cell
-										alt="Versatile"
-										src="/partners/versatile.png"
-									/>
-									<Cell
-										alt="Slingshot"
-										src="/partners/slingshot.png"
+										alt="Deloitte"
+										src="/partners/deloitte.png"
 									/>
 								</SimpleGrid>
 							</TabPanel>
 							<TabPanel>
 								<SimpleGrid
-									minChildWidth="250px"
-									spacing="40px"
-								>
-									<Cell
-										alt="Slingshot"
-										src="/partners/slingshot.png"
-									/>
-									<Cell
-										alt="Versatile"
-										src="/partners/versatile.png"
-									/>
-									<Cell
-										alt="Slingshot"
-										src="/partners/slingshot.png"
-									/>
-									<Cell
-										alt="Versatile"
-										src="/partners/versatile.png"
-									/>
-									<Cell
-										alt="Versatile"
-										src="/partners/versatile.png"
-									/>
-									<Cell
-										alt="Versatile"
-										src="/partners/versatile.png"
-									/>
-								</SimpleGrid>
+									columns={[2, null, 3]}
+									spacing="20px"
+									minChildWidth={{
+										base: 170,
+										sm: 170,
+										md: 250,
+										lg: 300,
+									}}
+									spacingY={0}
+								></SimpleGrid>
 							</TabPanel>
 							<TabPanel>
 								<SimpleGrid
-									minChildWidth="250px"
+									columns={[2, null, 3]}
 									spacing="40px"
-								>
-									<Cell
-										alt="Slingshot"
-										src="/partners/slingshot.png"
-									/>
-									<Cell
-										alt="Slingshot"
-										src="/partners/slingshot.png"
-									/>
-									<Cell
-										alt="Slingshot"
-										src="/partners/slingshot.png"
-									/>
-									<Cell
-										alt="Slingshot"
-										src="/partners/slingshot.png"
-									/>
-									<Cell
-										alt="Slingshot"
-										src="/partners/slingshot.png"
-									/>
-									<Cell
-										alt="Slingshot"
-										src="/partners/slingshot.png"
-									/>
-									<Cell
-										alt="Slingshot"
-										src="/partners/slingshot.png"
-									/>
-									<Cell
-										alt="Slingshot"
-										src="/partners/slingshot.png"
-									/>
-								</SimpleGrid>
+									minChildWidth={{
+										base: 170,
+										sm: 170,
+										md: 250,
+										lg: 300,
+									}}
+									spacingY={0}
+								></SimpleGrid>
 							</TabPanel>
 						</TabPanels>
 					</Tabs>
@@ -252,13 +211,13 @@ function Cell({ src, alt }: ImageCell): JSX.Element {
 	return (
 		<Popover>
 			<PopoverTrigger>
-				<Center my={10} height="80px">
-					<Image src={src} alt={alt} />{" "}
+				<Center bg="#D8D6EC" rounded="lg" mt={10}>
+					<Image src={src} alt={alt} />
 				</Center>
 			</PopoverTrigger>
-			<PopoverContent bg="#fff" color="#8287BE">
+			<PopoverContent bg="#D8D6EC" color="#8287BE">
 				<PopoverCloseButton />
-				<PopoverHeader>{alt}</PopoverHeader>{" "}
+				<PopoverHeader fontWeight={700}>{alt}</PopoverHeader>
 				<PopoverBody>Description of partner here</PopoverBody>
 			</PopoverContent>
 		</Popover>

--- a/src/pages/partners.tsx
+++ b/src/pages/partners.tsx
@@ -37,12 +37,12 @@ export default function partners(): ReactElement {
 				<ContainerInside align="center">
 					<Wrap justify="center" align="center" mt={50}>
 						<WrapItem>
-							<Box maxW="60ch" textAlign="left" mt={`20px`}>
+							<Box maxW="60ch" textAlign="left" mt={10}>
 								<Heading mb={10}>
 									A network for you to become a part of the
 									journey
 								</Heading>
-								<Text my="10px">
+								<Text my={5}>
 									Connect with us, take advantage of our
 									resources, and together we can build a
 									brighter future.
@@ -56,7 +56,7 @@ export default function partners(): ReactElement {
 						<WrapItem>
 							<Box textAlign="left">
 								<Image
-									maxH="300px"
+									maxH={300}
 									src="/timmy/32.png"
 									alt="Timmy with graduation cap"
 									display={{ base: "none", md: "block" }}
@@ -144,8 +144,8 @@ export default function partners(): ReactElement {
 						<TabPanels mt={10}>
 							<TabPanel>
 								<SimpleGrid
-									columns={[2, null, 3]}
-									spacing="20px"
+						columns={{sm: 2, md: 3}}								
+						spacing={6}
 									minChildWidth={{
 										base: 170,
 										sm: 140,
@@ -170,8 +170,8 @@ export default function partners(): ReactElement {
 							</TabPanel>
 							<TabPanel>
 								<SimpleGrid
-									columns={[2, null, 3]}
-									spacing="20px"
+						columns={{sm: 2, md: 3}}								
+									spacing={6}
 									minChildWidth={{
 										base: 170,
 										sm: 170,
@@ -183,9 +183,9 @@ export default function partners(): ReactElement {
 							</TabPanel>
 							<TabPanel>
 								<SimpleGrid
-									columns={[2, null, 3]}
-									spacing="40px"
-									minChildWidth={{
+						columns={{sm: 2, md: 3}}								
+						spacing={6}
+						minChildWidth={{
 										base: 170,
 										sm: 170,
 										md: 250,


### PR DESCRIPTION
Just for right now, we have three partners on the website, Slingshot, Versatile, and Deloitte, which are all on the Academic Partner's tab; in addition, the selected icon of the three types of patterns is altered and the dimensions are now mobile friendly (I hope)